### PR TITLE
fix: enhance table column resizer functionality and visibility

### DIFF
--- a/styles/udo-tables.css
+++ b/styles/udo-tables.css
@@ -211,41 +211,60 @@
 
 .resizable-table {
   width: 100%;
+  table-layout: fixed;
 }
 
 .resizable-table th,
 .resizable-table td {
   position: relative;
   overflow: visible;
+  box-sizing: border-box;
+}
+
+.resizable-table colgroup {
+  visibility: visible;
+}
+
+.resizable-table col {
+  visibility: visible;
 }
 
 .table-resize-handle {
   position: absolute;
   top: 0;
-  right: -3px;
-  width: 8px;
+  right: -4px;
+  width: 10px;
   height: 100%;
   cursor: col-resize;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: center;
   touch-action: none;
+  z-index: 10;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .table-resize-handle::after {
   content: '';
-  width: 2px;
-  height: 60%;
+  width: 3px;
+  height: 70%;
   border-radius: 9999px;
-  background: color-mix(in srgb, var(--udo-table-border) 70%, white 30%);
-  transition: background-color 0.2s ease, opacity 0.2s ease;
-  opacity: 0.65;
+  background: color-mix(in srgb, var(--udo-table-border) 80%, white 20%);
+  transition: background-color 0.15s ease, opacity 0.15s ease, width 0.15s ease;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .resizable-table th:hover .table-resize-handle::after,
+.table-resize-handle:hover::after {
+  opacity: 0.8;
+}
+
 .table-resize-handle--active::after {
   background: #2563eb;
   opacity: 1;
+  width: 4px;
 }
 
 .table-resize-handle--active {


### PR DESCRIPTION
Fixes the table column resizer to properly work with both basic and complex tables:

**CSS Improvements:**
- Add z-index: 10 to resize handles to ensure visibility above adjacent cells
- Increase handle width from 8px to 10px for better clickability
- Improve visual feedback with opacity transitions (hidden by default, visible on hover)
- Add user-select: none to prevent text selection during drag
- Ensure table-layout: fixed for consistent column sizing
- Make resize handle indicator more prominent when active (4px width)

**JavaScript Improvements:**
- Enhanced pointer event handling with try-catch for better browser compatibility
- Use capture phase for pointer events (more reliable drag behavior)
- Add explicit preventDefault() on pointer move events
- Improve pointer capture management with proper error handling
- Support complex tables with colspan: add resize handles at each column boundary
- Position handles correctly within spanned cells using percentage-based positioning
- Add data-column-index attribute to handles for debugging

**Complex Table Support:**
- Now works with tables that have multiple header rows
- Supports column spans (colspan > 1) with handles at internal boundaries
- Handles row spans (rowSpan > 1) correctly in column tracking
- Each column can be resized even in complex multi-level header tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)